### PR TITLE
Update zluda_installer.py to include CDLL for non-windows platforms

### DIFF
--- a/modules/zluda_installer.py
+++ b/modules/zluda_installer.py
@@ -4,6 +4,7 @@ import site
 import ctypes
 import shutil
 import zipfile
+import platform
 import urllib.request
 from typing import Union
 from modules import rocm
@@ -27,6 +28,11 @@ hipBLASLt_enabled = False
 
 nightly = os.environ.get("ZLUDA_NIGHTLY", "0") == "1"
 
+if platform.system() == "Windows":
+    LibraryLoaderClass = ctypes.WinDLL
+else:
+    LibraryLoaderClass = ctypes.CDLL
+
 
 class ZLUDAResult(ctypes.Structure):
     _fields_ = [
@@ -36,14 +42,14 @@ class ZLUDAResult(ctypes.Structure):
 
 
 class ZLUDALibrary:
-    internal: ctypes.WinDLL
+    internal: LibraryLoaderClass
 
-    def __init__(self, internal: ctypes.WinDLL):
+    def __init__(self, internal: LibraryLoaderClass):
         self.internal = internal
 
 
 class Core(ZLUDALibrary):
-    def __init__(self, internal: ctypes.WinDLL):
+    def __init__(self, internal: LibraryLoaderClass):
         internal.zluda_get_hip_object.restype = ZLUDAResult
         internal.zluda_get_hip_object.argtypes = [ctypes.c_void_p, ctypes.c_int]
 


### PR DESCRIPTION
Attempting to launch on linux after the latest update causes an error: Module ctypes has no attribute 'windll'.

I recommend testing on your end first. It doesn't break anything on my end and did allow ZLUDA to be properly loaded but it's not thoroughly tested.