### PR TITLE
Fix for RuntimeError: Expected a single top-level function

### DIFF
--- a/modules/dml/amp/autocast_mode.py
+++ b/modules/dml/amp/autocast_mode.py
@@ -1,7 +1,7 @@
 import importlib
 from typing import Any, Optional
 import torch
-
+import functools
 
 ops = ["torch.Tensor.__matmul__", "torch.addbmm", "torch.addmm", "torch.addmv", "torch.addr", "torch.baddbmm", "torch.bmm", "torch.chain_matmul", "torch.linalg.multi_dot", "torch.nn.functional.conv1d", "torch.nn.functional.conv2d", "torch.nn.functional.conv3d", "torch.nn.functional.conv_transpose1d", "torch.nn.functional.conv_transpose2d", "torch.nn.functional.conv_transpose3d", "torch.nn.GRUCell", "torch.nn.functional.linear", "torch.nn.LSTMCell", "torch.matmul", "torch.mm", "torch.mv", "torch.prelu", "torch.nn.RNNCell", "torch.embedding"]
 supported_cast_pairs = {
@@ -9,17 +9,8 @@ supported_cast_pairs = {
     torch.float32: (torch.float16,),
 }
 
-
-def forward(op, args: tuple, kwargs: dict):
-    if not torch.dml.is_autocast_enabled:
-        return op(*args, **kwargs)
-    args = list(map(cast, args))
-    for kwarg in kwargs:
-        kwargs[kwarg] = cast(kwargs[kwarg])
-    return op(*args, **kwargs)
-
-
-def cast(tensor: torch.Tensor):
+def _cast_tensor(tensor: torch.Tensor):
+    """Casts a tensor to the autocast dtype if applicable."""
     if not torch.is_tensor(tensor):
         return tensor
     dtype: torch.dtype = tensor.dtype
@@ -27,24 +18,54 @@ def cast(tensor: torch.Tensor):
         return tensor
     return tensor.type(torch.dml.autocast_gpu_dtype)
 
+# This provides a stable object that the PyTorch JIT compiler can inspect.
+class _AutocastForwarder:
+    def __init__(self, op):
+        self.op = op
+        # Copying metadata helps with introspection and makes the wrapper
+        # more transparent to other tools, including the JIT compiler.
+        functools.update_wrapper(self, op)
 
-def cond(op: str):
-    if isinstance(op, str):
-        func_path = op.split('.')
+    def __call__(self, *args, **kwargs):
+        if not torch.dml.is_autocast_enabled:
+            return self.op(*args, **kwargs)
+        
+        # Cast all tensor arguments to the autocast dtype
+        args = list(map(_cast_tensor, args))
+        for kwarg in kwargs:
+            kwargs[kwarg] = _cast_tensor(kwargs[kwarg])
+            
+        return self.op(*args, **kwargs)
+
+def _patch_op(op_str: str):
+    """Dynamically finds and patches the specified PyTorch operation."""
+    if isinstance(op_str, str):
+        func_path = op_str.split('.')
+        # handles both functions (e.g., torch.matmul)
+        # and class methods (e.g., torch.Tensor.__matmul__)
         for i in range(len(func_path)-1, -1, -1):
             try:
-                resolved_obj = importlib.import_module('.'.join(func_path[:i]))
-                break
+                module_path = '.'.join(func_path[:i])
+                if module_path:
+                    resolved_obj = importlib.import_module(module_path)
+                    break
             except ImportError:
                 pass
+        else:
+            # built-in types which don't have a module
+            resolved_obj = __builtins__
+
         for attr_name in func_path[i:-1]:
             resolved_obj = getattr(resolved_obj, attr_name)
-        op = getattr(resolved_obj, func_path[-1])
-        setattr(resolved_obj, func_path[-1], lambda *args, **kwargs: forward(op, args, kwargs))
-
+            
+        original_op = getattr(resolved_obj, func_path[-1])  
+        setattr(resolved_obj, func_path[-1], _AutocastForwarder(original_op))
 
 for o in ops:
-    cond(o)
+    try:
+        _patch_op(o)
+    except (ImportError, AttributeError) as e:
+        print(f"Warning: Could not patch {o}. Reason: {e}")
 
 
 class autocast:


### PR DESCRIPTION
Fixes a RuntimeError that occurs during startup #13 #33  
Expected a single top-level function: modules\dml\amp\autocast_mode.py

The JIT compiler cannot resolve the source code of these dynamically-generated, anonymous lambda functions, which is a requirement for its scripting process. When kornia attempts to script a function or class that uses one of these patched operations, the JIT compilation fails.

An instance of _AutocastForwarder is now used to patch each operation. This provides a stable, inspectable object that the PyTorch JIT compiler can correctly handle. functools.update_wrapper is also used to ensure the wrapper is transparent to introspection tools.
