### PR TITLE
Add missing import when using ONNX

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from modules import sd_samplers_kdiffusion, sd_samplers_timesteps, sd_samplers_lcm, shared, sd_samplers_common, sd_schedulers
+from modules import sd_samplers_kdiffusion, sd_samplers_timesteps, sd_samplers_diffusers, sd_samplers_lcm, shared, sd_samplers_common, sd_schedulers
 
 # imports for functions that previously were here and are used by other modules
 from modules.sd_samplers_common import samples_to_image_grid, sample_to_image  # noqa: F401


### PR DESCRIPTION
Fixes the error `ONNX failed to initialize: name 'sd_samplers_diffusers' is not defined` when using ONNX